### PR TITLE
fix finnhub api key

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "dotenv": "^8.2.0"
   }
 }

--- a/src/app/views/user-stock/userStock.js
+++ b/src/app/views/user-stock/userStock.js
@@ -14,7 +14,7 @@ import {
 } from "react-vis";
 
 function UserStock() {
-  
+
   // Variables containing stock information for this page
   const [stock, setStock] = useState(null);
   const [stockPrices, setStockPrices] = useState(null);
@@ -51,10 +51,10 @@ function UserStock() {
     }
   }
 
-  // Performs a GET request to the Finnhub API to get some prices from the stock 
+  // Performs a GET request to the Finnhub API to get some prices from the stock
   async function getStockPrices() {
     let finnhubResponse = await axios.get(
-      `https://finnhub.io/api/v1/stock/candle?symbol=${stock.symbol}&resolution=1&from=1572651390&to=1572910590&token=${process.env.REACT_APP_FINNHUB_SECRET}`
+      `https://finnhub.io/api/v1/stock/candle?symbol=${stock.symbol}&resolution=1&from=1572651390&to=1572910590&token=${process.env.REACT_APP_FINNHUB_API_KEY}`
     );
 
     // If we have a valid response, we can set the object to represent the prices


### PR DESCRIPTION
I created a file `.env` that has a constant REACT_APP_FINNHUB_API_KEY. Then in `userStock` it uses it to construct the URL request to finnhub. `.env` is already in the gitignore.

<img width="463" alt="Capture" src="https://user-images.githubusercontent.com/16506186/97136037-3ec55480-170f-11eb-9fb1-004561206188.PNG">
